### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "livescript-loader",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"author": "Derk Bell",
 	"description": "LiveScript loader module for webpack",
 	"dependencies": {
-		"LiveScript": "1.3.1",
+		"livescript": "1.4.x",
 		"loader-utils": "0.2.x"
 	},
 	"repository": {


### PR DESCRIPTION
LiveScript has changed name to `livescript` on NPM as of 1.4.0, because npm no longer alows mixed-case package names.
