### PR TITLE
Fix issue when livescript loader is used with disabled source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = function(source){
   query = LoaderUtils.parseQuery(this.query);
   import$(config, query);
   result = LiveScript.compile(source, config);
+  if (config.map === 'none') {
+    return result;
+  }
   result.map.setSourceContent(lsRequest, source);
   result.map._file = lsRequest;
   this.callback(null, result.code, JSON.parse(result.map.toString()));

--- a/index.ls
+++ b/index.ls
@@ -20,6 +20,8 @@ module.exports = (source) !->
 	config <<< query
 
 	result = LiveScript.compile source, config
+	if config.map == 'none'
+		return result
 	result.map.set-source-content ls-request, source
 	result.map._file = ls-request # Monkeypatch filename in sourcemap
 	@callback null, result.code, JSON.parse(result.map.to-string!)


### PR DESCRIPTION
Using livescript loader with parameter map=none result in error. Example Webpack config.

```
module.exports = {
    module: {
    loaders: [
        {
            test: /\.ls/,
            loader: "livescript-loader?map=none"
        }
    ]
}
```

This is because Livescript.compile() function returns string when sourceMap is disabled. Then Webpack loader should return this code instead of calling this.callback(null, source, map);

See code in pull request and check it with Webpack docs https://webpack.github.io/docs/how-to-write-a-loader.html
